### PR TITLE
[GATHERGUARD-85] add taxes type to get list endpoint

### DIFF
--- a/src/Client/TaxesClient.php
+++ b/src/Client/TaxesClient.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use Jauntin\TaxesSdk\Exception\ClientException;
+use Jauntin\TaxesSdk\TaxType;
 
 class TaxesClient
 {
@@ -22,9 +23,9 @@ class TaxesClient
     /**
      * @throws ClientException
      */
-    public function getTaxes(array $params): array
+    public function getTaxes(array $params, TaxType $taxType): array
     {
-        $url      = sprintf('%s/api/v1/taxes', $this->serviceUrl);
+        $url      = sprintf('%s/api/v1/taxes/%s', $this->serviceUrl, $taxType->value);
         $response = $this->handleRequest(
             fn(PendingRequest $pendingRequest) => $pendingRequest->get($url, $this->prepareQuery($params))
         );

--- a/src/Query/CalculateQuery.php
+++ b/src/Query/CalculateQuery.php
@@ -112,15 +112,6 @@ class CalculateQuery
         return new Calculated($result);
     }
 
-    public function get(TaxType $taxType): array
-    {
-        try {
-            return $this->client->getTaxes($this->params, $taxType);
-        } catch (ClientException $e) {
-            return [];
-        }
-    }
-
     /**
      * @throws ValidationException
      */

--- a/src/Query/CalculateQuery.php
+++ b/src/Query/CalculateQuery.php
@@ -112,6 +112,15 @@ class CalculateQuery
         return new Calculated($result);
     }
 
+    public function get(TaxType $taxType): array
+    {
+        try {
+            return $this->client->getTaxes($this->params, $taxType);
+        } catch (ClientException $e) {
+            return [];
+        }
+    }
+
     /**
      * @throws ValidationException
      */

--- a/src/TaxesService.php
+++ b/src/TaxesService.php
@@ -40,6 +40,14 @@ class TaxesService
     }
 
     /**
+     * @throws ClientException
+     */
+    public function getList(TaxType $taxType, array $params): array
+    {
+        return $this->client->getTaxes($params, $taxType);
+    }
+
+    /**
      * @return CalculateQuery
      */
     private function newQuery(): CalculateQuery


### PR DESCRIPTION
### What does this PR address?

In taxes microservice we have endpoint `GET|HEAD  api/v1/taxes/{taxType}` but our sdk sends request to `api/v1/taxes` and it returned 404 all the time. 

After changes Sdk can send request to `GET /api/v1/taxes/municipal?state=KY&municipalCode=1017` and return not empty response 
```
[
    {
        "state": "KY",
        "type": "AdChrg",
        "code": "AFKY1",
        "rate": 0.05,
        "municipalCode": "1017",
        "municipalName": "LOUISVILLE - URBAN"
    }
]
```

### Pre-merge Checklist

- [ ] PR has been linked to an issue
- [x] Tests created or updated as necessary
- [x] Author has manually tested the update
- [ ] Reviewer has manually tested the update
- [ ] Upon merge, commit history is clean
