### PR TITLE
[TAXES-21] add effectiveDate parameter to search locations endpoint

### DIFF
--- a/src/Client/TaxesClient.php
+++ b/src/Client/TaxesClient.php
@@ -66,16 +66,21 @@ class TaxesClient
     /**
      * @param string $state
      * @param string $search
+     * @param string|null $effectiveDate
      *
      * @return array
      *
      * @throws ClientException
      */
-    public function lookupTaxLocations(string $state, string $search): array
+    public function lookupTaxLocations(string $state, string $search, ?string $effectiveDate = null): array
     {
         $url      = sprintf('%s/api/v1/taxes/lookup/locations', $this->serviceUrl);
+        $params   = ['state' => $state, 'searchString' => $search];
+        if ($effectiveDate) {
+            $params['effectiveDate'] = $effectiveDate;
+        }
         $response = $this->handleRequest(
-            fn(PendingRequest $pendingRequest) => $pendingRequest->get($url, ['state' => $state, 'searchString' => $search])
+            fn(PendingRequest $pendingRequest) => $pendingRequest->get($url, $params)
         );
 
         return $response->json();

--- a/src/Query/CalculateQuery.php
+++ b/src/Query/CalculateQuery.php
@@ -89,13 +89,13 @@ class CalculateQuery
     }
 
     /**
-     * @param DateTime|string $startDate
+     * @param DateTime|string $effectiveDate
      *
      * @return $this
      */
-    public function setStartDate(DateTime|string $startDate): self
+    public function setEffectiveDate(DateTime|string $effectiveDate): self
     {
-        $this->params['startDate'] = $startDate instanceof DateTime ? $startDate->format('Y-m-d') : $startDate;
+        $this->params['effectiveDate'] = $effectiveDate instanceof DateTime ? $effectiveDate->format('Y-m-d') : $effectiveDate;
 
         return $this;
     }
@@ -129,7 +129,7 @@ class CalculateQuery
             'include.*'     => ['string'],
             'exclude'       => ['array'],
             'exclude.*'     => ['string'],
-            'startDate'     => ['date'],
+            'effectiveDate' => ['date'],
         ]);
     }
 }

--- a/src/TaxesService.php
+++ b/src/TaxesService.php
@@ -20,7 +20,7 @@ class TaxesService
      */
     public function taxes(array $taxes): CalculateQuery
     {
-         return $this->newQuery()->taxes($taxes);
+        return $this->newQuery()->taxes($taxes);
     }
 
     /**
@@ -34,9 +34,9 @@ class TaxesService
     /**
      * @throws ClientException
      */
-    public function lookupTaxLocations(string $state, string $search): array
+    public function lookupTaxLocations(string $state, string $search, ?string $effectiveDate = null): array
     {
-        return $this->client->lookupTaxLocations($state, $search);
+        return $this->client->lookupTaxLocations($state, $search, $effectiveDate);
     }
 
     /**

--- a/tests/Unit/TaxesFacadeTest.php
+++ b/tests/Unit/TaxesFacadeTest.php
@@ -89,7 +89,7 @@ class TaxesFacadeTest extends TestCase
         $calculated = TaxesFacade::taxes([TaxType::MUNICIPAL])
             ->state('KY')
             ->withMunicipal('0001')
-            ->setStartDate(Carbon::parse('2022-12-01'))
+            ->setEffectiveDate(Carbon::parse('2022-12-01'))
             ->calculate(10000);
 
         $this->assertInstanceOf(Calculated::class, $calculated);


### PR DESCRIPTION
### What does this PR address?

Add `effectiveDate` parameter to `/api/v1/taxes/lookup/locations` endpoint

### Pre-merge Checklist

- [ ] PR has been linked to an issue
- [ ] Tests created or updated as necessary
- [ ] Author has manually tested the update
- [ ] Reviewer has manually tested the update
- [ ] Upon merge, commit history is clean
